### PR TITLE
Remove obsolete Rusk methods

### DIFF
--- a/phoenix/rusk.proto
+++ b/phoenix/rusk.proto
@@ -8,10 +8,6 @@ package phoenix;
 import "transaction.proto";
 import "keys.proto";
 
-message Provisioner {
-	bytes address = 1;
-}
-
 message EchoRequest {}
 message EchoResponse {}
 
@@ -24,27 +20,6 @@ message ValidateStateTransitionResponse {
   bool success = 1;
 }
 
-message DistributeRequest {
-	fixed64 total_reward = 1;
-	repeated Provisioner addresses = 2;
-	PublicKey pk = 3;
-}
-
-message DistributeResponse {
-	bool success = 1;
-}
-
-message WithdrawRequest {
-	bytes signature = 1;
-	bytes address = 2;
-	fixed64 value = 3;
-	PublicKey pk = 4;
-}
-
-message WithdrawResponse{
-	bool success = 1;
-}
-
 service Rusk {
   // Simple echo request
   rpc Echo(EchoRequest) returns (EchoResponse) {}
@@ -52,8 +27,4 @@ service Rusk {
   // listed transactions is inconsistent
   rpc ValidateStateTransition(ValidateStateTransitionRequest)
       returns (ValidateStateTransitionResponse) {}
-	rpc Distribute(DistributeRequest)
-			returns (DistributeResponse) {}
-	rpc Withdraw(WithdrawRequest)
-			returns (WithdrawResponse) {}
 }


### PR DESCRIPTION
These were used for the demos, but will not be used in production.